### PR TITLE
feat: conditional rendering of unthanking form elements

### DIFF
--- a/src/v2/autorespond/thanks/createResponse.ts
+++ b/src/v2/autorespond/thanks/createResponse.ts
@@ -1,6 +1,6 @@
 import { MessageButton } from 'discord.js';
 import { MessageActionRow, MessageSelectMenu } from 'discord.js';
-import type { User, MessageOptions } from 'discord.js';
+import type { User, MessageOptions, Client } from 'discord.js';
 import type { EmbedField, Collection } from 'discord.js';
 
 import { clampLength } from '../../utils/clampStr.js';
@@ -8,23 +8,23 @@ import { createEmbed } from '../../utils/discordTools.js';
 
 export function createResponse(
   thankedUsers: Collection<string, User>,
-  authorId: string
+  authorId: string,
+  client: Client
 ): MessageOptions {
   const title = `Point${thankedUsers.size === 1 ? '' : 's'} received!`;
 
-  const description = `<@!${authorId}> has given a point to ${
-    thankedUsers.size === 1
-      ? `<@!${thankedUsers.first().id}>`
-      : 'the users mentioned below'
-  }!`;
+  const description = `<@!${authorId}> has given a point to ${thankedUsers.size === 1
+    ? `<@!${thankedUsers.first().id}>`
+    : 'the users mentioned below'
+    }!`;
 
   const fields: EmbedField[] =
     thankedUsers.size > 1
       ? [...thankedUsers].map(([, u], i) => ({
-          inline: false,
-          name: `${(i + 1).toString()}.`,
-          value: `<@!${u.id}>`,
-        }))
+        inline: false,
+        name: `${(i + 1).toString()}.`,
+        value: `<@!${u.id}>`,
+      }))
       : [];
 
   const output = createEmbed({
@@ -36,26 +36,30 @@ export function createResponse(
     title,
   }).embed;
 
+  const clientId = client.user.id;
+
+  const components = authorId === clientId ? [
+    new MessageActionRow().addComponents(
+      thankedUsers.size > 1
+        ? new MessageSelectMenu()
+          .setCustomId(`thanks🤔${authorId}🤔select`)
+          .setPlaceholder('Accidentally Thank someone? Un-thank them here!')
+          .setMinValues(1)
+          .setOptions(
+            thankedUsers.map(user => ({
+              label: clampLength(user.username, 25),
+              value: user.id,
+            }))
+          )
+        : new MessageButton()
+          .setCustomId(`thanks🤔${authorId}🤔${thankedUsers.first().id}`)
+          .setStyle('SECONDARY')
+          .setLabel('This was an accident, UNDO!')
+    ),
+  ] : [];
+
   return {
     embeds: [output],
-    components: [
-      new MessageActionRow().addComponents(
-        thankedUsers.size > 1
-          ? new MessageSelectMenu()
-              .setCustomId(`thanks🤔${authorId}🤔select`)
-              .setPlaceholder('Accidentally Thank someone? Un-thank them here!')
-              .setMinValues(1)
-              .setOptions(
-                thankedUsers.map(user => ({
-                  label: clampLength(user.username, 25),
-                  value: user.id,
-                }))
-              )
-          : new MessageButton()
-              .setCustomId(`thanks🤔${authorId}🤔${thankedUsers.first().id}`)
-              .setStyle('SECONDARY')
-              .setLabel('This was an accident, UNDO!')
-      ),
-    ],
+    components,
   };
 }

--- a/src/v2/autorespond/thanks/index.ts
+++ b/src/v2/autorespond/thanks/index.ts
@@ -36,12 +36,12 @@ const getReply = async (msg: Message): Promise<undefined | Message> => {
   }
 };
 
-const handleThanks = async (msg: Message): Promise<void> => {
+const handleThanks = async (msg: Message, client: Client): Promise<void> => {
   const botId = msg.author.bot;
   const reply = await getReply(msg);
   if (botId || (msg.mentions.users.size === 0 && !reply)) {
     if (
-      ['GUILD_PRIVATE_THREAD','GUILD_PUBLIC_THREAD'].includes(msg.channel.type)
+      ['GUILD_PRIVATE_THREAD', 'GUILD_PUBLIC_THREAD'].includes(msg.channel.type)
     ) {
       await handleThreadThanks(msg);
     }
@@ -118,9 +118,8 @@ const handleThanks = async (msg: Message): Promise<void> => {
               value: `<@!${u.id}>\n${diff} minute${diff === 1 ? '' : 's'}.`,
             };
           }),
-          footerText: `You can only give a point to a user every ${POINT_LIMITER_IN_MINUTES} minute${
-            Number.parseInt(POINT_LIMITER_IN_MINUTES) === 1 ? '' : 's'
-          }.`,
+          footerText: `You can only give a point to a user every ${POINT_LIMITER_IN_MINUTES} minute${Number.parseInt(POINT_LIMITER_IN_MINUTES) === 1 ? '' : 's'
+            }.`,
           provider: 'spam',
           title: 'Cooldown alert!',
         }).embed,
@@ -134,7 +133,7 @@ const handleThanks = async (msg: Message): Promise<void> => {
   }
 
   thankableUsers.forEach(async user => pointHandler(user.id, msg));
-  const msgData = createResponse(thankableUsers, msg.author.id);
+  const msgData = createResponse(thankableUsers, msg.author.id, client);
 
   const response = await msg.channel.send(msgData);
 

--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -122,7 +122,7 @@ client.once('ready', async (): Promise<void> => {
 
   try {
     await client.user.setAvatar('./logo.png');
-  } catch {}
+  } catch { }
 });
 
 const detectVarLimited = limitFnByUser(detectVar, {
@@ -154,17 +154,17 @@ client.on('messageCreate', msg => {
   }
 
   if (NON_COMMAND_MSG_TYPES.has(msg.channel.type) && msg.guild) {
-    handleNonCommandGuildMessages(msg);
+    handleNonCommandGuildMessages(msg, client);
   }
 });
 
-const handleNonCommandGuildMessages = async (msg: Message) => {
+const handleNonCommandGuildMessages = async (msg: Message, client: Client) => {
   const quoteLessContent = stripMarkdownQuote(msg.content);
   if (msg.author.bot) {
     return;
   }
   if (isWebdevAndWebDesignServer(msg) && isThanksMessage(quoteLessContent)) {
-    handleThanks(msg);
+    handleThanks(msg, client);
   }
   await detectDeprecatedCommands(msg);
   await detectJustAsk(msg);


### PR DESCRIPTION
Essentially, when you thank someone you get an option to unthank them.

However this also appears for everybody else for some reason. Of course if other people try to unthank you will correctly get the message "This isn't your thanks to undo!" , but the form elements should not display in the first place!