### PR TITLE
fix: korean phrase in please command

### DIFF
--- a/src/v2/commands/please/handlers/english.ts
+++ b/src/v2/commands/please/handlers/english.ts
@@ -1,6 +1,6 @@
 export const english = [
   'english',
-  `English only please - انجليزي فقط من فضلك - Само на английски - 请只说英语 - Pouze v angličtině - Kun engelsk takk - Angla Nur Bonvolu - Vain englanti - Anglais seulement s'il vous plait - Bitte nur Englisch - Μόνο Αγγλικά - Hanya Bahasa Inggris - Solo inglese per favore - 英語のみ - 영어 만주세요 - Tikai angļu valodā, lūdzu - Tik angliškai Prašau - Solo inglés por favor - Пожалуйста, только на английском - Iba v angličtine - Sadece ingilizce lütfen - Тільки англійською мовою - Proszę tylko po angielsku
+  `English only please - انجليزي فقط من فضلك - Само на английски - 请只说英语 - Pouze v angličtině - Kun engelsk takk - Angla Nur Bonvolu - Vain englanti - Anglais seulement s'il vous plait - Bitte nur Englisch - Μόνο Αγγλικά - Hanya Bahasa Inggris - Solo inglese per favore - 英語のみ - 영어로만 해주세요 - Tikai angļu valodā, lūdzu - Tik angliškai Prašau - Solo inglés por favor - Пожалуйста, только на английском - Iba v angličtine - Sadece ingilizce lütfen - Тільки англійською мовою - Proszę tylko po angielsku
 
 This allows us to effectively moderate and gives everyone an opportunity to join in on the conversation.`,
 ] as const;


### PR DESCRIPTION
Updated the Korean part of the `/please` command because the current one doesn't sound right.